### PR TITLE
Add Solr / Elastic to the Database category.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -341,7 +341,8 @@ Check out my [blog](https://blog.sindresorhus.com) and follow me on [Twitter](ht
 - [MongoDB](https://github.com/ramnes/awesome-mongodb) - NoSQL database.
 - [RethinkDB](https://github.com/d3viant0ne/awesome-rethinkdb)
 - [TinkerPop](https://github.com/mohataher/awesome-tinkerpop) - Graph computing framework.
-
+- [Solr](https://github.com/xingh/awesome-solr) - Document Index.
+- [Elastic](https://github.com/dzharii/awesome-elasticsearch) - Elastic Search Index.
 
 ## Media
 


### PR DESCRIPTION
Pull request from @xingh.
- title: Solr
- head: Databases
- desc: Document Index.
- url: https://github.com/Anant/awesome-solr
- stars: 82
- size: 32
- redir: https://github.com/xingh/awesome-solr
- extra: -
- extra: +- [Elastic](https://github.com/dzharii/awesome-elasticsearch) - Elastic Search Index.
- updated: 2021-09-23 19:16
- created: 2017-03-11 19:44
- pull: https://github.com/sindresorhus/awesome/pull/904

<!-- Please fill in the **bold** fields -->

**[Insert URL to the list here.]**

https://github.com/xingh/awesome-solr
https://github.com/dzharii/awesome-elasticsearch

**[Explain what this list is about and why it should be included here.]**

So much of technology now uses Solr / Elastic for search, we should link to it.

Solr powers Amazon CloudSearch / Solr is used in various industries to power search. 
Elastic powers Azure Cloud Search / Elastic is used around the world for search and analytics. 

\[ boilerplate snipped \]